### PR TITLE
PR: Replaces Node with Nginx as a proper web server to fix port 3000 issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+logs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,18 +30,25 @@ services:
         aliases:
           - mysql
 
-  node:
-    image: shipyard.path.med.umich.edu/kpmp/orion-node
-    build:
-      context: ./node
-    ports:
-      - "${ENV_REACT_DEV_SERVER_PORT:-3000}:3000"
+  nginx:
+    build: ./nginx
     volumes:
-      - "${ENV_REACT_APPDIR}:/usr/src/app"
+      - ./logs:/var/logs
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/app.template:/etc/nginx/conf.d/app.template
+      - ${ENV_REACT_APPDIR}:/usr/share/nginx/html
     environment:
-      NODE_ENV: ${ENV_DOCKER_ENVIRONMENT}
+      ENV_APP_PORT: ${ENV_APP_PORT}
+      ENV_APP_HOSTNAME: ${ENV_APP_HOSTNAME}
+      NODE_ENV: ${ENV_DOCKER_ENVIRONMENT:-dev}
+    ports:
+      - ${ENV_APP_PORT}:${ENV_APP_PORT}
+    command: /bin/bash -c "envsubst '$${ENV_APP_HOSTNAME},$${ENV_APP_PORT}' < /etc/nginx/conf.d/app.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+    restart: always
     networks:
       local:
+        aliases:
+          - nginx
 
 volumes:
   mysqldb:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,1 @@
+FROM nginx:1.12

--- a/nginx/app.template
+++ b/nginx/app.template
@@ -1,0 +1,9 @@
+server {
+    listen ${ENV_APP_PORT} default_server;
+    server_name ${ENV_APP_HOSTNAME};
+    index index.html index.htm;
+    location / {
+        root /usr/share/nginx/html/build;
+        try_files $uri /index.html;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,45 @@
+worker_processes  1;
+error_log  /var/logs/nginx.log debug;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_comp_level 6;
+    gzip_min_length 1100;
+    gzip_buffers 16 8k;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/js
+        text/xml
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/rss+xml
+        image/svg+xml;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
Removes node (and thusly create-react-app's webpack-dev-server) and replaces it with Nginx as a launchpad for future SSL domain and security. Node is no longer needed, as it's only job was to run an npm script. That is now replaced by "npm run build" to launch a new version at any time.